### PR TITLE
update to typings 1.0

### DIFF
--- a/.typingsrc
+++ b/.typingsrc
@@ -1,0 +1,3 @@
+{
+    "rejectUnauthorized": false
+}

--- a/StreamStats.csproj
+++ b/StreamStats.csproj
@@ -56,6 +56,7 @@
     <TypeScriptSourceMap>false</TypeScriptSourceMap>
   </PropertyGroup>
   <ItemGroup>
+    <None Include=".typingsrc" />
     <Content Include="gulpfile.js" />
     <Content Include="src\appConfig.js" />
     <Content Include="src\Assets\images\Animatedkayakers.gif" />

--- a/_references.js
+++ b/_references.js
@@ -1,4 +1,4 @@
-/// <reference path="typings/main.d.ts" />
+/// <reference path="typings/index.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Extensions/String.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Extensions/SurveyRound.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Models/Point.d.ts" />

--- a/_references.js.map
+++ b/_references.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"_references.js","sourceRoot":"","sources":["_references.ts"],"names":[],"mappings":"AAAA,0CAA0C;AAC1C,yFAAyF;AACzF,8FAA8F;AAC9F,oFAAoF;AACpF,wFAAwF;AACxF,oGAAoG;AACpG,gGAAgG;AAChG,iGAAiG;AACjG,uFAAuF;AACvF,wFAAwF;AACxF,2FAA2F;AAC3F,yGAAyG;AACzG,4FAA4F;AAC5F,2FAA2F"}
+{"version":3,"file":"_references.js","sourceRoot":"","sources":["_references.ts"],"names":[],"mappings":"AAAA,2CAA2C;AAC3C,yFAAyF;AACzF,8FAA8F;AAC9F,oFAAoF;AACpF,wFAAwF;AACxF,oGAAoG;AACpG,gGAAgG;AAChG,iGAAiG;AACjG,uFAAuF;AACvF,wFAAwF;AACxF,2FAA2F;AAC3F,yGAAyG;AACzG,4FAA4F;AAC5F,2FAA2F"}

--- a/_references.ts
+++ b/_references.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="typings/main.d.ts" />
+﻿/// <reference path="typings/index.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Extensions/String.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Extensions/SurveyRound.d.ts" />
 /// <reference path="bower_components/wim_angular/dist/typings/Models/Point.d.ts" />

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-  "ambientDependencies": {
+  "globalDependencies": {
     "angular": "github:DefinitelyTyped/DefinitelyTyped/angularjs/angular.d.ts#1c4a34873c9e70cce86edd0e61c559e43dfa5f75",
     "angular-ui-bootstrap": "github:DefinitelyTyped/DefinitelyTyped/angular-ui-bootstrap/angular-ui-bootstrap.d.ts#5d3116c83ea2aa0afcfef61c8cbbf6d7a4cbc09f",
     "angular-ui-router": "github:DefinitelyTyped/DefinitelyTyped/angular-ui-router/angular-ui-router.d.ts#655f8c1bf3c71b0e1ba415b36309604f79326ac8",


### PR DESCRIPTION
I couldn't find a way to install typings without disabling ssl with `rejectUnauthorized:false` in a .typingsrc file

links:
https://github.com/typings/typings/issues/106
https://github.com/typings/typings/issues/416
https://github.com/nodejs/node/issues/3742