### PR TITLE
Fixes #1331 - New Release 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/USGS-WiM/StreamStats/tree/dev)
   
   ### Added
-
+    
   ### Changed
-  - Changed URL for IA and NC supplemental gage pages to new location on S3
 
   ### Fixed
 
   ### Removed
+
+## [v.4.10.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.10.0) - 2022-06-16
+  
+  ### Added
+  - Added loader and disabled download button until longest flow path is downloaded
+  - Added Maine August Baseflow layer
+  - QPPQ additions
+    - Added line to CSV download that states which Regression Region's results are shown
+    - Added collapsible functionality to section in report
+    - Added citation to report section
+    
+  ### Changed
+  - Changed URL for IA and NC supplemental gage pages to new location on S3
+  - Renamed "New Streamstats Gage Modal" to "Streamstats Gage Modal"
+  - Shows Longest Flow Path automatically on the main map if returned from the services
+  - Changes to QPPQ
+    - The exceedance probabilities table in report is now sorted from greatest to least exceedance
+    - If the "Flow-Duration Curve Transfer Method" scenario is selected, the "Flow-Duration Statistics" scenario button is now selected by default and cannot be unselected while the "Flow-Duration Curve Transfer Method" scenario button is selected.
+    - The "Flow-Duration Curve Transfer Method" statistics group does not show up in the Report anymore. Instead, the same information appears in the "Flow-Duration Statistics" statistics group.
+
+  ### Removed
+  - Removed "StreamStats Gage page" link
 
 ## [v4.9.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.9.0) - 2022-05-19
 

--- a/dist/appConfig.js
+++ b/dist/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.9.0";
+configuration.version = "4.10.0";
 configuration.environment = 'development';
 
 configuration.baseurls =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "homepage": "https://github.com/USGS-WiM/StreamStats",
   "repository": "https://github.com/USGS-WiM/StreamStats",
   "authors": [

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.9.0";
+configuration.version = "4.10.0";
 configuration.environment = 'development';
 
 configuration.baseurls =


### PR DESCRIPTION
  ### Added
  - Added loader and disabled download button until longest flow path is downloaded
  - Added Maine August Baseflow layer
  - QPPQ additions
    - Added line to CSV download that states which Regression Region's results are shown
    - Added collapsible functionality to section in report
    - Added citation to report section

  ### Changed
  - Changed URL for IA and NC supplemental gage pages to new location on S3
  - Renamed "New Streamstats Gage Modal" to "Streamstats Gage Modal"
  - Shows Longest Flow Path automatically on the main map if returned from the services
  - Changes to QPPQ
    - The exceedance probabilities table in report is now sorted from greatest to least exceedance
    - If the "Flow-Duration Curve Transfer Method" scenario is selected, the "Flow-Duration Statistics" scenario button is now selected by default and cannot be unselected while the "Flow-Duration Curve Transfer Method" scenario button is selected.
    - The "Flow-Duration Curve Transfer Method" statistics group does not show up in the Report anymore. Instead, the same information appears in the "Flow-Duration Statistics" statistics group.

  ### Removed
  - Removed "StreamStats Gage page" link
