### PR TITLE
Fixes #1182 - Disable stream grid for regions with StormDrain application 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - SSstormwaterDelineation url in appconfig
   - Mystic configuration in appconfig
   - DRB configuration in appconfig
+  - StreamGrid is not visible by default for StormDrain applications
   
   ### Fixed
 

--- a/src/Controllers/MapController.js
+++ b/src/Controllers/MapController.js
@@ -1302,20 +1302,24 @@ var StreamStats;
                 if (this.regionServices.regionMapLayerList.length < 1)
                     return;
                 var layerList = [];
+                var visibleList = [];
                 var roots = this.regionServices.regionMapLayerList.map(function (layer) {
                     layerList.push(layer[1]);
+                    if (this.regionServices.selectedRegion.Applications.indexOf("StormDrain") > -1 && layer[0] == 'StreamGrid') {
+                        visibleList.push(false);
+                    }
+                    else {
+                        visibleList.push(true);
+                    }
                 });
-                var visible = true;
-                if (regionId == 'MRB')
-                    visible = false;
-                layerList.forEach(function (layer) {
+                layerList.forEach(function (layer, index) {
                     _this.layers.overlays[regionId + "_region" + layer] =
                         {
                             name: String(layer),
                             group: regionId + " Map layers",
                             url: configuration.baseurls['StreamStatsMapServices'] + configuration.queryparams['SSStateLayers'],
                             type: 'agsDynamic',
-                            visible: visible,
+                            visible: visibleList[index],
                             layerOptions: {
                                 opacity: 1,
                                 layers: [layer],

--- a/src/Controllers/MapController.ts
+++ b/src/Controllers/MapController.ts
@@ -1738,20 +1738,27 @@ module StreamStats.Controllers {
 
             if (this.regionServices.regionMapLayerList.length < 1) return;
 
-            var layerList = [];
+            var layerList = []; // Map layers for selected Region
+            var visibleList = []; // Visibility of map layers for selected Region
             var roots = this.regionServices.regionMapLayerList.map(function (layer) {
                 layerList.push(layer[1])
+                if (this.regionServices.selectedRegion.Applications.indexOf("StormDrain") > -1 && layer[0] == 'StreamGrid') {
+                    // StreamGrid should not be visible by default for StormDrain applications
+                    visibleList.push(false);
+                } else {
+                    visibleList.push(true);
+                }
+                
             });
-            var visible = true;
-            if (regionId == 'MRB') visible = false;
-            layerList.forEach(layer => {
+
+            layerList.forEach((layer, index) => {
                 this.layers.overlays[regionId + "_region" + layer] = 
                 {
                     name: String(layer),
                     group: regionId + " Map layers",
                     url: configuration.baseurls['StreamStatsMapServices'] + configuration.queryparams['SSStateLayers'],
                     type: 'agsDynamic',
-                    visible: visible,
+                    visible:  visibleList[index],
                     layerOptions: {
                         opacity: 1,
                         layers: [layer],


### PR DESCRIPTION
Closes #1182

StreamGrid is not visible by default for StormDrain applications. The ExcludePoly is visible by default.