### PR TITLE
Release v4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased](https://github.com/USGS-WiM/StreamStats/tree/dev)
   
+### Added 
+
+-
+
+### Changed  
+
+-
+
+### Deprecated 
+
+-
+
+### Removed 
+
+- 
+
+### Fixed  
+
+- 
+
+### Security  
+
+- 
+
+## [v4.11.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.11.0) - 2022-10-14
+
   ### Added
   - Flow Anywhere Method from StreamEst
 
@@ -18,17 +44,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Mystic configuration in appconfig
   - DRB configuration in appconfig
   - StreamGrid is not visible by default for StormDrain applications
-  
-  ### Fixed
-
-  ### Removed
-
-## [v.4.10.1](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.10.1) - 2022-07-20
+  ## [v4.10.1](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.10.1) - 2022-07-20
   
   ### Added
   - Added Channel-width Methods Weighting results to downloaded CSV
 
-## [v.4.10.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.10.0) - 2022-06-16
+## [v4.10.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.10.0) - 2022-06-16
   
   ### Added
   - Added loader and disabled download button until longest flow path is downloaded

--- a/dist/appConfig.js
+++ b/dist/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.10.1";
+configuration.version = "4.11.0";
 configuration.environment = 'development';
 
 configuration.baseurls =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "homepage": "https://github.com/USGS-WiM/StreamStats",
   "repository": "https://github.com/USGS-WiM/StreamStats",
   "authors": [

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.10.1";
+configuration.version = "4.11.0";
 configuration.environment = 'development';
 
 configuration.baseurls =


### PR DESCRIPTION
### Added
  - Flow Anywhere Method from StreamEst

  ### Changed
  - Channel Weighting services URL 
  - NWIS Page link from legacy real-time page to Next Generation Monitoring Location page
  - FlowAnywhereMapServices to StreamStatsMapServices because IowaStreamEst map services were moved from gis.wim.usgs.gov to gis.streamstats.usgs.gov
  - Flow Anywhere application shows published NWIS Drainage Area instead of GIS-calculated drainage area
  - Appconfig - SSstormwaterDelineation url in appconfig, Mystic configuration in appconfig, DRB configuration in appconfig (this was already on dev and never brought into gituhb)
 