### PR TITLE
Fixes #1495 - release v4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   
 ### Added 
 
+### Changed  
+
+### Deprecated 
+
+### Removed 
+  
+### Fixed  
+
+### Security  
+
+## [v4.12.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.12.0) - 2023-01-11
+  
+### Added 
+
 - Begin Drainage Area and End Drainage Area attributes to Indiana Coordinated Discharge report
 - Ability to download gage pages as a CSV
 
@@ -18,10 +32,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - StreamStats Gage Page link in gage popups to a button
 - Updated to Google Analytics 4
 - Updated code.json
-
-### Deprecated 
-
--
 
 ### Removed 
 
@@ -35,10 +45,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Printed gage page now shows all table content instead of cutting of scrolling tables
 - Disclaimers on report are now not delimited by commas when downloaded as a CSV
 
-### Security  
-
-
-
 ## [v4.11.1](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.11.1) - 2022-10-14
 
 ### Added 
@@ -48,8 +54,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed  
 
 - Issue where state layers were not showing up 
-
-
 
 ## [v4.11.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.11.0) - 2022-10-14
 

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "StreamStats",
     "organization": "U.S. Geological Survey",
     "description": "StreamStats client application",
-    "version": "4.11.1",
+    "version": "4.12.0",
     "status": "Production",	
 
     "permissions": {
@@ -46,7 +46,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2022-12-14"
+      "metadataLastUpdated": "2022-01-11"
     }
   }
 ]

--- a/dist/appConfig.js
+++ b/dist/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.11.1";
+configuration.version = "4.12.0";
 configuration.environment = 'development';
 
 configuration.baseurls =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "homepage": "https://github.com/USGS-WiM/StreamStats",
   "repository": "https://github.com/USGS-WiM/StreamStats",
   "authors": [

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.11.1";
+configuration.version = "4.12.0";
 configuration.environment = 'development';
 
 configuration.baseurls =


### PR DESCRIPTION
### Added 

- Begin Drainage Area and End Drainage Area attributes to Indiana Coordinated Discharge report
- Ability to download gage pages as a CSV

### Changed  

- Moved NC And IA gage pages links inside StreamStats gage page modal
- Watershed symbols in the legend
- StreamStats Gage Page link in gage popups to a button
- Updated to Google Analytics 4
- Updated code.json

### Removed 

- Legacy NWIS link for gage pages
- NWIS page link in gage popups
- Angulartics
  
### Fixed  

- Bug that shows out of range parameter warning after parameters have been edited to be within range and report is reopened
- Printed gage page now shows all table content instead of cutting of scrolling tables
- Disclaimers on report are now not delimited by commas when downloaded as a CSV
