### PR TITLE
Fix manage queue bug related to #1755

### DIFF
--- a/src/Controllers/BatchProcessorController.js
+++ b/src/Controllers/BatchProcessorController.js
@@ -816,6 +816,9 @@ var StreamStats;
                         this.selectBatchProcessorTab("submitBatch");
                     }
                 }
+                else if (this.manageQueue) {
+                    this.selectBatchProcessorTab("manageQueue");
+                }
                 this.retrieveBatchStatusMessages().then(function (response) {
                     _this.batchStatusMessageList = response;
                 });

--- a/src/Controllers/BatchProcessorController.ts
+++ b/src/Controllers/BatchProcessorController.ts
@@ -1310,7 +1310,8 @@ module StreamStats.Controllers {
         } else if (this.modalService.modalOptions.tabName == "manageQueue") {
             this.selectBatchProcessorTab("submitBatch")
         }
-
+      } else if (this.manageQueue) {
+        this.selectBatchProcessorTab("manageQueue")
       }
       this.retrieveBatchStatusMessages().then((response) => {
         this.batchStatusMessageList = response;


### PR DESCRIPTION
I missed a bug in #1756 where if manageBPqueue=true and no URL parameters were sent, the Submit Batch tab would open when opening the Batch Processor modal.