### PR TITLE
Adds log scale functionality for #1707: Gageplots Feedback - Annual Peak Streamflow plot

### DIFF
--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -3065,6 +3065,14 @@ var StreamStats;
                     floodSeries.hide();
                 }
             };
+            GagePageController.prototype.containsNegatives = function () {
+                if (this.dailyValuesOnly.some(function (v) { return v <= 0; })) {
+                    return true;
+                }
+                if (this.dailyValuesOnly.some(function (v) { return v > 0; })) {
+                    return false;
+                }
+            };
             GagePageController.prototype.toggleLogLinear = function () {
                 var chart = $('#chart1').highcharts();
                 if (this.logScale) {

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -3438,6 +3438,16 @@ public createDailyRasterPlot(): void {
             }
         }
         
+        //checks if there are any negative values
+        public containsNegatives() {
+            if (this.dailyValuesOnly.some(v => v <= 0)) {
+                return true
+            }
+            if (this.dailyValuesOnly.some(v => v > 0)) {
+                return false
+            }
+        }
+        
         //checkbox for change linear to log scale
         public logScale = false; 
         public toggleLogLinear () {


### PR DESCRIPTION
Seems like the `containsNegatives()` function was deleted at some point. Adding that back to allow log scale checkbox to operate again per request in #1707. 

Does not close issue -- leave #1707 open. 