### PR TITLE
Fixes #1827 Add instructions about zipped up folder Batch Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Note about Batch Processor output projection
 - appConfig files for dev and test machines
+- Instructions about shapefile structure to Batch Processor Submit Batch tab
 
 ### Changed
 

--- a/dist/Views/batchprocessor.html
+++ b/dist/Views/batchprocessor.html
@@ -53,6 +53,7 @@
                         <li>Shapefile must be a point shapefile. Polyline, polygon, and multipoint geometries cannot be
                             processed.
                         </li>
+                        <li>Shapefile must be compressed to a .zip file that contains a .shp, .shx, .prj, and .dbf file in the top-level folder.</li>
                         <li>Only the first 250 points will be processed.</li>
                         <li>Only points contained within the requested State/Region will be processed.</li>
                         <li>Results will be provided in the same coordinate system as the shapefile.</li>

--- a/src/Views/batchprocessor.html
+++ b/src/Views/batchprocessor.html
@@ -53,6 +53,7 @@
                         <li>Shapefile must be a point shapefile. Polyline, polygon, and multipoint geometries cannot be
                             processed.
                         </li>
+                        <li>Shapefile must be compressed to a .zip file that contains a .shp, .shx, .prj, and .dbf file in the top-level folder.</li>
                         <li>Only the first 250 points will be processed.</li>
                         <li>Only points contained within the requested State/Region will be processed.</li>
                         <li>Results will be provided in the same coordinate system as the shapefile.</li>


### PR DESCRIPTION
Closes #1827

If we get more user tickets about this, we can consider changing the SS-BatchProcessor services to look for the shapefile components in subfolders of the .zip file. 