### PR TITLE
Fixes #1839 Add warning message if BP services are down 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Instructions about shapefile structure to Batch Processor Submit Batch tab
 - Checkbox option to ignore exclusion polygons on non-Production servers
 - Allow option to run Dev Batch Processor points that are in exclusion polygons
+- Error message in Batch Processor is Batch Processor services aren't working
 
 ### Changed
 

--- a/src/Controllers/BatchProcessorController.js
+++ b/src/Controllers/BatchProcessorController.js
@@ -47,7 +47,7 @@ var StreamStats;
             __extends(BatchProcessorController, _super);
             function BatchProcessorController($scope, $http, modalService, nssService, modal, toaster, $sce) {
                 var _this = _super.call(this, $http, configuration.baseurls.StreamStats) || this;
-                _this.displayWarning = false;
+                _this.displayError = false;
                 $scope.vm = _this;
                 _this.sce = $sce;
                 _this.modalInstance = modal;
@@ -90,6 +90,7 @@ var StreamStats;
                 _this.flowStatsCollapsed = false;
                 _this.init();
                 _this.selectBatchProcessorTab(_this.selectedBatchProcessorTabName);
+                _this.displayWarning = configuration.showBPWarning;
                 return _this;
             }
             BatchProcessorController.prototype.Close = function () {
@@ -131,9 +132,12 @@ var StreamStats;
                     configuration.queryparams["Regions"];
                 var request = new WiM.Services.Helpers.RequestInfo(url, true);
                 var self = this;
-                this.Execute(request).then(function (response) {
+                this.Execute(request)
+                    .then(function (response) {
                     self.regionList = response.data;
                     _this.regionListSpinner = false;
+                }, function (error) {
+                    _this.displayError = true;
                 });
             };
             BatchProcessorController.prototype.getFlowStatsAndParams = function (rcode) {

--- a/src/Controllers/BatchProcessorController.ts
+++ b/src/Controllers/BatchProcessorController.ts
@@ -198,9 +198,10 @@ module StreamStats.Controllers {
     public flowStatsCollapsed;
 
     // warning message
-    public displayWarning = false;
+    public displayWarning;
     public warningMessage: string;
     public sce: any;
+    public displayError = false;
 
     //Constructor
     //-+-+-+-+-+-+-+-+-+-+-+-
@@ -265,6 +266,7 @@ module StreamStats.Controllers {
       this.flowStatsCollapsed = false;
       this.init();
       this.selectBatchProcessorTab(this.selectedBatchProcessorTabName);
+      this.displayWarning = configuration.showBPWarning;
     }
 
     //Methods
@@ -314,10 +316,14 @@ module StreamStats.Controllers {
         new WiM.Services.Helpers.RequestInfo(url, true);
       var self = this;
 
-      this.Execute(request).then((response: any) => {
+      this.Execute(request)
+      .then((response: any) => {
         self.regionList = response.data;
         // console.log(self.regionList);
         this.regionListSpinner = false;
+      },(error) => {
+        // console.log(error)
+        this.displayError = true;
       });
     }
 

--- a/src/Views/batchprocessor.html
+++ b/src/Views/batchprocessor.html
@@ -12,10 +12,17 @@
 <!-- Start modal body-->
 <div class="modal-body">
 
-    <!-- Warning Message -->
-    <div id="warningMessageContent" ng-if="!vm.showWarning">
-        <div class="wim-warning" ng-bind-html="vm.convertUnsafe(vm.warningMessage)" style="overflow-x:auto"></div>
+    <!-- Error Message -->
+    <div ng-if="vm.displayError">
+        <div class="wim-error" style="overflow-x:auto; padding:5px;">
+            <b>Some Batch Processor features are currently unavailable. Please check back soon. Contact streamstats@usgs.gov for support.</b>
+        </div>
+        <br>
+    </div>
 
+    <!-- Warning Message -->
+    <div id="warningMessageContent" ng-if="vm.displayWarning">
+        <div class="wim-warning" ng-bind-html="vm.convertUnsafe(vm.warningMessage)" style="overflow-x:auto; padding:5px;"></div>
     </div>
 
     <!-- Start batch processor tabs -->

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -671,6 +671,10 @@ div.leaflet-top > .elevation {
 
     .wim-warning {
        background-color: #fdb81e !important;
+    }
+
+    .wim-error {
+        background-color: #FF2B00 !important;
      }
 
 /*


### PR DESCRIPTION
Closes #1839 

Quick fix to show a warning message at the top of the BP modal, if the Region endpoint isn't working (which typically indicates that the BP is down).

This isn't really comprehensive (for example, if the user initially goes straight to the Batch Status tab, they will not see the error box). But hopefully it will help explain things a little bit if users go to the Submit Batch tab and see they aren't able to submit a batch because the services are down.

Also:
- Added some padding to the yellow wim-warning box just so it looks nicer
- The appConfig boolean showBPWarning wasn't actually working-- fixed this