### PR TITLE
#1849 set DC stormdrain minZoom to 14

### DIFF
--- a/dist/appConfig.js
+++ b/dist/appConfig.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],

--- a/dist/appConfig_dev.js
+++ b/dist/appConfig_dev.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],

--- a/dist/appConfig_test.js
+++ b/dist/appConfig_test.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],

--- a/src/appConfig_dev.js
+++ b/src/appConfig_dev.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],

--- a/src/appConfig_test.js
+++ b/src/appConfig_test.js
@@ -277,6 +277,7 @@ configuration.regions = [
                 "type": 'agsDynamic',
                 "visible": true,
                 "layerOptions": {
+                    "minZoom": 14,
                     "zIndex": 1,
                     "format": "png8",
                     "layers": [0, 1, 2],


### PR DESCRIPTION
This is a quick fix for #1849 before we have time to work on the actual requested feature.

Washington, D.C. Stormwater region StormDrainPipes layer is now set to minZoom 14. 

I went ahead and made this change on DevWeb.