### PR TITLE
#1848 Release v4.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [v4.19.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.19.0) - 2023-11-30
+
+### Added
+
 - Note about Batch Processor output projection
 - appConfig files for dev and test machines
 - Instructions about shapefile structure to Batch Processor Submit Batch tab
@@ -26,17 +40,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use SS Pourpoint ssExcludePolygon service instead of directly using state map services
 - Batch Processor Download Stream Grids tab files now also include Exclude Polys
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Latitude and Longitude columns swapped in the Elevation profile CSV export
 - Email address required for Batch Processor Batch Status tab
 - Stream Grids tab sometimes shows repeated regions
-
-### Security
 
 ## [v4.18.1](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.18.1) - 2023-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
-## [v4.19.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.19.0) - 2023-11-30
+## [v4.19.0](https://github.com/USGS-WiM/StreamStats/releases/tag/v4.19.0) - 2023-12-01
 
 ### Added
 

--- a/code.json
+++ b/code.json
@@ -46,7 +46,7 @@
     },
 
     "date": {
-      "metadataLastUpdated": "2022-01-11"
+      "metadataLastUpdated": "2023-12-01"
     }
   }
 ]

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "StreamStats",
     "organization": "U.S. Geological Survey",
     "description": "StreamStats client application",
-    "version": "4.18.1",
+    "version": "4.19.0",
     "status": "Production",	
 
     "permissions": {

--- a/dist/appConfig.js
+++ b/dist/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."

--- a/dist/appConfig_dev.js
+++ b/dist/appConfig_dev.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."

--- a/dist/appConfig_test.js
+++ b/dist/appConfig_test.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.18.1",
+  "version": "4.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "StreamStats",
-  "version": "4.18.1",
+  "version": "4.19.0",
   "homepage": "https://github.com/USGS-WiM/StreamStats",
   "repository": "https://github.com/USGS-WiM/StreamStats",
   "authors": [

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."

--- a/src/appConfig_dev.js
+++ b/src/appConfig_dev.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."

--- a/src/appConfig_test.js
+++ b/src/appConfig_test.js
@@ -1,5 +1,5 @@
 var configuration = {};
-configuration.version = "4.18.1";
+configuration.version = "4.19.0";
 configuration.environment = 'development';
 configuration.showWarningModal = false;
 configuration.warningModalMessage = "Due to heavy demand, StreamStats is currently experiencing system interruptions. If you receive errors, please try back again later.<br><br>Thank you for your patience."


### PR DESCRIPTION
### Added

- Note about Batch Processor output projection
- appConfig files for dev and test machines
- Instructions about shapefile structure to Batch Processor Submit Batch tab
- Checkbox option to ignore exclusion polygons on non-Production servers
- Allow option to run Dev Batch Processor points that are in exclusion polygons
- Error message in Batch Processor is Batch Processor services aren't working
- "Start Next Batch" button to Batch Processor Manage Queue tab
- Ability to refresh batches in Batch Processor Manage Queue tab
- Mystic River Basin region 

### Changed

- Batch Processor streamgrids retrieved from different endpoints
- Batch Processor times displayed in local time instead of UTC
- Use SS Pourpoint ssExcludePolygon service instead of directly using state map services
- Batch Processor Download Stream Grids tab files now also include Exclude Polys

### Fixed

- Latitude and Longitude columns swapped in the Elevation profile CSV export
- Email address required for Batch Processor Batch Status tab