### PR TITLE
Fixes #1925 Stage vs. Discharge Plot - Fix plot scale so all values are shown in linear scale

### DIFF
--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -3051,6 +3051,26 @@ var StreamStats;
                 var measuredDataMin = Math.min.apply(Math, this.measuredObj
                     .filter(function (obj) { return typeof obj.y === 'number' && !isNaN(obj.y); })
                     .map(function (obj) { return obj.y; }));
+                var peakDataMax = Math.max.apply(Math, this.formattedDischargePeakDates
+                    .filter(function (obj) { return typeof obj.y === 'number' && !isNaN(obj.y); })
+                    .map(function (obj) { return obj.y; }));
+                var peakDataMin = Math.min.apply(Math, this.formattedDischargePeakDates
+                    .filter(function (obj) { return typeof obj.y === 'number' && !isNaN(obj.y); })
+                    .map(function (obj) { return obj.y; }));
+                var yAxisMax;
+                var yAxisMin;
+                if (peakDataMax > measuredDataMax) {
+                    yAxisMax = peakDataMax;
+                }
+                else {
+                    yAxisMax = measuredDataMax;
+                }
+                if (peakDataMin < measuredDataMin) {
+                    yAxisMin = peakDataMin;
+                }
+                else {
+                    yAxisMin = measuredDataMin;
+                }
                 var self = this;
                 this.dischargeChartConfig = {
                     chart: {
@@ -3105,8 +3125,8 @@ var StreamStats;
                             if (!self.logScaleDischarge) {
                                 var positions = [];
                                 var axis = this;
-                                var min = Math.max(axis.min, measuredDataMin);
-                                var max = Math.min(axis.max, measuredDataMax);
+                                var min = Math.max(axis.min, yAxisMin);
+                                var max = Math.min(axis.max, yAxisMax);
                                 var tick = Math.floor(min) > 0 ? Math.floor(min) - 1 : 1;
                                 var maxTick = max + 2;
                                 var increment = (maxTick - tick) > 18 ? 2 : 1;

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -3450,8 +3450,26 @@ public createDischargePlot(): void {
         .filter(obj => typeof obj.y === 'number' && !isNaN(obj.y))
         .map(obj => obj.y)
     );
-    // console.log("max3147", measuredDataMax)
-    // console.log("min3147", measuredDataMin)
+    let peakDataMax = Math.max.apply(Math, this.formattedDischargePeakDates
+        .filter(obj => typeof obj.y === 'number' && !isNaN(obj.y))
+        .map(obj => obj.y)
+    );
+    let peakDataMin = Math.min.apply(Math, this.formattedDischargePeakDates
+        .filter(obj => typeof obj.y === 'number' && !isNaN(obj.y))
+        .map(obj => obj.y)
+    );
+    let yAxisMax;
+    let yAxisMin;
+    if (peakDataMax > measuredDataMax) {
+        yAxisMax = peakDataMax;
+    } else {
+        yAxisMax = measuredDataMax;
+    }
+    if (peakDataMin < measuredDataMin) {
+        yAxisMin = peakDataMin;
+    } else {
+        yAxisMin = measuredDataMin;
+    }
     var self = this
     this.dischargeChartConfig = {
         chart: {
@@ -3506,8 +3524,8 @@ public createDischargePlot(): void {
                 if (!self.logScaleDischarge) {
                     var positions = [];
                     var axis = this;
-                    var min = Math.max(axis.min, measuredDataMin);
-                    var max = Math.min(axis.max, measuredDataMax);
+                    var min = Math.max(axis.min, yAxisMin);
+                    var max = Math.min(axis.max, yAxisMax);
                     var tick = Math.floor(min) > 0 ? Math.floor(min) - 1 : 1;
                     var maxTick = max + 2;
                     var increment = (maxTick - tick) > 18? 2 : 1;


### PR DESCRIPTION
Plots that only have peak data were having an issue with the linear scale because the yAxis `tickPositioner` for the Stage vs. Discharge plot was only using the USGS Measured data to gather min and max. I added a check for peak data values, which for some of these gages was nonexistent, so now it uses whichever data is available or the overall min/max. 

Gages to test that previously showed nothing in linear scale: 

- 05513450
- 03419000
- 06125520

Closes #1925 