### PR TITLE
Fixes #1971: Gageplots - fix Print appearance, Fixes #1976: Add note about toggling data series

### DIFF
--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -2886,6 +2886,7 @@ var StreamStats;
                 var chart = $('#chart1').highcharts();
                 chart.showLoading('Loading...');
                 setTimeout(function () {
+                    _this_1.updateFloodStats();
                     var extremes = chart.xAxis[0].getExtremes();
                     var min = new Date(extremes.min);
                     var max = new Date(extremes.max);
@@ -2917,7 +2918,6 @@ var StreamStats;
                     }
                     chart.hideLoading();
                 }, 100);
-                this.updateFloodStats();
             };
             GagePageController.prototype.choosePeakYear = function () {
                 var _this_1 = this;
@@ -3790,6 +3790,7 @@ var StreamStats;
             GagePageController.prototype.updateFloodStats = function () {
                 var _this_1 = this;
                 var chart = $('#chart1').highcharts();
+                console.log('called');
                 var extremes = chart.xAxis[0].getExtremes();
                 var min = new Date(extremes.min);
                 var max = new Date(extremes.max);
@@ -3801,6 +3802,7 @@ var StreamStats;
                 chart.series.forEach(function (series) {
                     if (series.name.includes('AEP flood')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
+                            console.log('hitting');
                             series.update({ visible: true });
                             var AEPformattedName_1 = series.name.substring(0, series.name.length - 18);
                             series.update({ data: [
@@ -3828,6 +3830,7 @@ var StreamStats;
                     }
                     if (series.name.includes('Year Low Flow')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
+                            console.log('here');
                             series.update({ visible: true });
                             var lowFlowFormattedName_1 = series.name.replaceAll('_', ' ');
                             series.update({ data: [

--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -683,7 +683,8 @@ var StreamStats;
                     .split("T")[0];
                 var url;
                 var now = new Date();
-                var today = now.getUTCFullYear() + '-' + now.getUTCMonth() + 1 + '-' + now.getUTCDate();
+                var month = now.getUTCMonth() + 1;
+                var today = now.getUTCFullYear() + '-' + month + '-' + now.getUTCDate();
                 if (this.instFlow.length > 0) {
                     url = 'https://nwis.waterservices.usgs.gov/nwis/dv/?format=json&sites=' + this.gage.code + '&parameterCd=00060&statCd=00003&startDT=1900-01-01&endDT=' + twoWeeksAgo;
                 }

--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -2096,7 +2096,7 @@ var StreamStats;
                         }
                     },
                     subtitle: {
-                        text: 'Click and drag to zoom in. Hold down shift key to pan.<br>AEP = Annual Exceedance Probability',
+                        text: 'Click and drag to zoom in. Hold down shift key to pan.<br>Click legend items to toggle data off and on.<br>AEP = Annual Exceedance Probability',
                         align: 'center'
                     },
                     rangeSelector: {
@@ -2146,19 +2146,6 @@ var StreamStats;
                             allowNegativeLog: true
                         },
                         plotLines: [{ value: null, color: null, width: null, zIndex: null, label: { text: null }, id: 'plotlines' }]
-                    },
-                    plotOptions: {
-                        series: {
-                            events: {
-                                legendItemClick: function () {
-                                    var visibility = this.visible ? 'visible' : 'hidden';
-                                    if (!confirm('The series is currently ' +
-                                        visibility + '. Do you want to change that?')) {
-                                        return false;
-                                    }
-                                }
-                            }
-                        }
                     },
                     series: [
                         {
@@ -3107,7 +3094,7 @@ var StreamStats;
                         align: 'center'
                     },
                     subtitle: {
-                        text: 'Click and drag in the plot area to zoom in',
+                        text: 'Click and drag in the plot area to zoom in.<br>Click legend items to toggle data off and on.',
                         align: 'center'
                     },
                     xAxis: {
@@ -3396,7 +3383,7 @@ var StreamStats;
                         align: 'center'
                     },
                     subtitle: {
-                        text: 'Click and drag in the plot area to zoom in',
+                        text: 'Click and drag in the plot area to zoom in.<br>Click legend items to toggle data off and on.',
                         align: 'center'
                     },
                     xAxis: {
@@ -3790,7 +3777,6 @@ var StreamStats;
             GagePageController.prototype.updateFloodStats = function () {
                 var _this_1 = this;
                 var chart = $('#chart1').highcharts();
-                console.log('called');
                 var extremes = chart.xAxis[0].getExtremes();
                 var min = new Date(extremes.min);
                 var max = new Date(extremes.max);
@@ -3802,7 +3788,6 @@ var StreamStats;
                 chart.series.forEach(function (series) {
                     if (series.name.includes('AEP flood')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
-                            console.log('hitting');
                             series.update({ visible: true });
                             var AEPformattedName_1 = series.name.substring(0, series.name.length - 18);
                             series.update({ data: [
@@ -3830,7 +3815,6 @@ var StreamStats;
                     }
                     if (series.name.includes('Year Low Flow')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
-                            console.log('here');
                             series.update({ visible: true });
                             var lowFlowFormattedName_1 = series.name.replaceAll('_', ' ');
                             series.update({ data: [

--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -537,6 +537,7 @@ var StreamStats;
                 var _this_1 = this;
                 var url = configuration.baseurls.GageStatsServices + configuration.queryparams.GageStatsServicesStations + this.gage.code;
                 this.floodStatsURL = url;
+                console.log('GetFloodFreqURL', url);
                 var request = new WiM.Services.Helpers.RequestInfo(url, true, WiM.Services.Helpers.methodType.GET, 'json');
                 this.Execute(request).then(function (response) {
                     var data = response.data;
@@ -622,6 +623,7 @@ var StreamStats;
                         }
                     } while (data.length > 0);
                     _this_1.floodFreq = AEPchartData;
+                    console.log(_this_1.floodFreq);
                     _this_1.altFloodFreq = altAEPchartData;
                     _this_1.oneDayStats = oneDayChartData;
                     _this_1.sevenDayStats = sevenDayChartData;

--- a/src/Controllers/GagePageController.js
+++ b/src/Controllers/GagePageController.js
@@ -537,7 +537,6 @@ var StreamStats;
                 var _this_1 = this;
                 var url = configuration.baseurls.GageStatsServices + configuration.queryparams.GageStatsServicesStations + this.gage.code;
                 this.floodStatsURL = url;
-                console.log('GetFloodFreqURL', url);
                 var request = new WiM.Services.Helpers.RequestInfo(url, true, WiM.Services.Helpers.methodType.GET, 'json');
                 this.Execute(request).then(function (response) {
                     var data = response.data;
@@ -623,7 +622,6 @@ var StreamStats;
                         }
                     } while (data.length > 0);
                     _this_1.floodFreq = AEPchartData;
-                    console.log(_this_1.floodFreq);
                     _this_1.altFloodFreq = altAEPchartData;
                     _this_1.oneDayStats = oneDayChartData;
                     _this_1.sevenDayStats = sevenDayChartData;
@@ -2149,6 +2147,19 @@ var StreamStats;
                         },
                         plotLines: [{ value: null, color: null, width: null, zIndex: null, label: { text: null }, id: 'plotlines' }]
                     },
+                    plotOptions: {
+                        series: {
+                            events: {
+                                legendItemClick: function () {
+                                    var visibility = this.visible ? 'visible' : 'hidden';
+                                    if (!confirm('The series is currently ' +
+                                        visibility + '. Do you want to change that?')) {
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
+                    },
                     series: [
                         {
                             name: 'Annual Peak Streamflow',
@@ -2895,18 +2906,18 @@ var StreamStats;
                             chart.series[index].hide();
                             chart.series[index].update({ data: [{
                                         x: new Date(minAndMax.min),
-                                        y: 5000
+                                        y: chart.series[index].processedYData[0]
                                     }, {
                                         x: new Date(minAndMax.max),
-                                        y: 5000
+                                        y: chart.series[index].processedYData[1]
                                     }
                                 ] });
                         });
                         floodSeries.show();
                     }
-                    _this_1.updateFloodStats();
                     chart.hideLoading();
                 }, 100);
+                this.updateFloodStats();
             };
             GagePageController.prototype.choosePeakYear = function () {
                 var _this_1 = this;
@@ -3790,6 +3801,7 @@ var StreamStats;
                 chart.series.forEach(function (series) {
                     if (series.name.includes('AEP flood')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
+                            series.update({ visible: true });
                             var AEPformattedName_1 = series.name.substring(0, series.name.length - 18);
                             series.update({ data: [
                                     {
@@ -3810,9 +3822,13 @@ var StreamStats;
                                     }
                                 } });
                         }
+                        else {
+                            series.update({ visible: false });
+                        }
                     }
-                    if (series.name.includes('Year Low Flow') && series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
+                    if (series.name.includes('Year Low Flow')) {
                         if (series.linkedParent.name === _this_1.selectedFloodFreqStats.name) {
+                            series.update({ visible: true });
                             var lowFlowFormattedName_1 = series.name.replaceAll('_', ' ');
                             series.update({ data: [
                                     {
@@ -3832,6 +3848,9 @@ var StreamStats;
                                         }
                                     }
                                 } });
+                        }
+                        else {
+                            series.update({ visible: false });
                         }
                     }
                 });

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -3286,6 +3286,7 @@ public chooseFloodStats() {
     let chart = $('#chart1').highcharts();
     chart.showLoading('Loading...')
     setTimeout(() => {
+        this.updateFloodStats();
         let extremes = chart.xAxis[0].getExtremes();
         let min = new Date(extremes.min)
         let max = new Date(extremes.max)
@@ -3317,7 +3318,6 @@ public chooseFloodStats() {
         }
         chart.hideLoading();
     }, 100);
-    this.updateFloodStats(); //this messes up the way the loading message works, but allows the printing to look right for some reason
 }
 
 //dropdown for choosing year to plot peaks
@@ -4195,6 +4195,7 @@ public createDailyRasterPlot(): void {
 
         public updateFloodStats() {
             let chart = $('#chart1').highcharts();
+            console.log('called')
             let extremes = chart.xAxis[0].getExtremes();
             let min = new Date(extremes.min)
             let max = new Date(extremes.max)
@@ -4206,6 +4207,7 @@ public createDailyRasterPlot(): void {
             chart.series.forEach(series => {
                 if (series.name.includes('AEP flood')) {
                     if (series.linkedParent.name === this.selectedFloodFreqStats.name) {
+                        console.log('hitting');
                         series.update({visible: true});
                         let AEPformattedName = series.name.substring(0, series.name.length-18);
                         series.update({data: [
@@ -4232,6 +4234,7 @@ public createDailyRasterPlot(): void {
                 } 
                 if (series.name.includes('Year Low Flow')) {
                     if (series.linkedParent.name === this.selectedFloodFreqStats.name) {
+                        console.log('here');
                         series.update({visible: true});
                         let lowFlowFormattedName = series.name.replaceAll('_',' ');
                         series.update({data: [

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -792,7 +792,7 @@ module StreamStats.Controllers {
         public getFloodFreq() {
             var url = configuration.baseurls.GageStatsServices + configuration.queryparams.GageStatsServicesStations + this.gage.code;
             this.floodStatsURL = url;
-            //console.log('GetFloodFreqURL', url)
+            console.log('GetFloodFreqURL', url)
             var request: WiM.Services.Helpers.RequestInfo = new WiM.Services.Helpers.RequestInfo(url, true, WiM.Services.Helpers.methodType.GET, 'json');
             this.Execute(request).then(
                 (response: any) => {
@@ -879,6 +879,7 @@ module StreamStats.Controllers {
                         }
                 } while (data.length > 0);
                 this.floodFreq = AEPchartData;
+                console.log(this.floodFreq);
                 this.altFloodFreq = altAEPchartData;
                 this.oneDayStats = oneDayChartData;
                 this.sevenDayStats = sevenDayChartData;

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -943,8 +943,9 @@ module StreamStats.Controllers {
                     .toISOString()
                     .split("T")[0];
             let url;
-            let now = new Date()
-            let today = now.getUTCFullYear() + '-' + now.getUTCMonth() + 1 + '-' + now.getUTCDate();
+            let now = new Date();
+            let month = now.getUTCMonth() + 1;
+            let today = now.getUTCFullYear() + '-' + month + '-' + now.getUTCDate();
             if (this.instFlow.length > 0) {
                 url = 'https://nwis.waterservices.usgs.gov/nwis/dv/?format=json&sites=' + this.gage.code + '&parameterCd=00060&statCd=00003&startDT=1900-01-01&endDT=' + twoWeeksAgo;
             } else {

--- a/src/Controllers/GagePageController.ts
+++ b/src/Controllers/GagePageController.ts
@@ -300,7 +300,6 @@ module StreamStats.Controllers {
                         exporting : { buttons: {contextButton: {menuItems: string[]}}},
                         xAxis: {  type: string, events: { afterSetExtremes: Function}, gridLineWidth: number, min: number, max: number, title: {text: string}, custom: { allowNegativeLog: Boolean }},
                         yAxis: { title: {text: string}, gridLineWidth: number, custom: { allowNegativeLog: Boolean }, plotLines: [{value: number, color: string, width: number, zIndex: number, label: {text: string}, id: string}]},
-                        plotOptions: { series: {events: {legendItemClick: Function}}},
                         series: { name: string; showInNavigator: boolean, tooltip: { headerFormat: string, pointFormatter: Function}, turboThreshold: number; type: string, color: string, 
                                 fillOpacity: number, lineWidth: number, data: number[], linkedTo: string, visible: boolean, id: string, zIndex: number, marker: {symbol: string, radius: number}, showInLegend: boolean; }[]; };
         dischargeChartConfig: {  
@@ -2479,7 +2478,7 @@ module StreamStats.Controllers {
                     squareSymbol: null,
                     labelFormatter: function() {
                     return this.name
-                    //     if (this.name === 'Shaded Daily Statistics') {
+                    //     if (this.name === 'Shaded Daily Statistics') { //leaving this here in case we want to workshop a custom legend item more in the future
                     //     return this.name + '<img src="./images/shadedLegend.png" width="15" height="15">'
                     // } else {
                     //     return this.name
@@ -2487,7 +2486,7 @@ module StreamStats.Controllers {
                 }
                 },
                 subtitle: {
-                    text: 'Click and drag to zoom in. Hold down shift key to pan.<br>AEP = Annual Exceedance Probability',
+                    text: 'Click and drag to zoom in. Hold down shift key to pan.<br>Click legend items to toggle data off and on.<br>AEP = Annual Exceedance Probability',
                     align: 'center'
                 },
                 rangeSelector: {
@@ -2513,15 +2512,9 @@ module StreamStats.Controllers {
                     type: 'datetime',
                     events: {
                         afterSetExtremes: function() {
-                            //console.log('the x axis has been resized')
-                            // let chart = $('#chart1').highcharts();
-                            // chart.showLoading('Loading...')
-                            // setTimeout(() => {
                                 self.updateShadedStats();
                                 self.updatePeaksAfterZoom();
                                 self.updateFloodStats();
-                                //chart.hideLoading();
-                            // }, 100);
                             }
                     },
                     gridLineWidth: 0,
@@ -2543,19 +2536,6 @@ module StreamStats.Controllers {
                         allowNegativeLog: true
                     },
                     plotLines: [{value: null, color: null, width: null, zIndex: null, label: {text: null}, id: 'plotlines'}]
-                },
-                plotOptions: {
-                    series: {
-                        events: {
-                            legendItemClick: function () {
-                                const visibility = this.visible ? 'visible' : 'hidden';
-                                if (!confirm('The series is currently ' +
-                                            visibility + '. Do you want to change that?')) {
-                                    return false;
-                                }
-                            }
-                        }
-                    }
                 },
                 series  : [
                 {
@@ -3507,7 +3487,7 @@ public createDischargePlot(): void {
             align: 'center'
         },
         subtitle: {
-            text: 'Click and drag in the plot area to zoom in',
+            text: 'Click and drag in the plot area to zoom in.<br>Click legend items to toggle data off and on.',
             align: 'center'
         },
         xAxis: {
@@ -3799,7 +3779,7 @@ public createDailyRasterPlot(): void {
             align: 'center'
         },
         subtitle: {
-            text: 'Click and drag in the plot area to zoom in',
+            text: 'Click and drag in the plot area to zoom in.<br>Click legend items to toggle data off and on.',
             align: 'center'
         },
         xAxis: {
@@ -4195,7 +4175,6 @@ public createDailyRasterPlot(): void {
 
         public updateFloodStats() {
             let chart = $('#chart1').highcharts();
-            console.log('called')
             let extremes = chart.xAxis[0].getExtremes();
             let min = new Date(extremes.min)
             let max = new Date(extremes.max)
@@ -4207,7 +4186,6 @@ public createDailyRasterPlot(): void {
             chart.series.forEach(series => {
                 if (series.name.includes('AEP flood')) {
                     if (series.linkedParent.name === this.selectedFloodFreqStats.name) {
-                        console.log('hitting');
                         series.update({visible: true});
                         let AEPformattedName = series.name.substring(0, series.name.length-18);
                         series.update({data: [
@@ -4234,7 +4212,6 @@ public createDailyRasterPlot(): void {
                 } 
                 if (series.name.includes('Year Low Flow')) {
                     if (series.linkedParent.name === this.selectedFloodFreqStats.name) {
-                        console.log('here');
                         series.update({visible: true});
                         let lowFlowFormattedName = series.name.replaceAll('_',' ');
                         series.update({data: [

--- a/src/Views/gagepage.html
+++ b/src/Views/gagepage.html
@@ -221,12 +221,13 @@
                             </table>
                         </div>
                     </div>
+                    <div style="break-after:page"></div>
                     <div ng-if="!vm.chartConfig" class="panel panel-default reportSpinner">
                         &nbsp;<i class="fa fa-spinner fa-3x fa-spin loadingSpinner"></i>
                     </div>
                     <center>
                         <div class="well well-sm" style="background-color:#EBF0F5;" ng-if="vm.chartConfig">
-                            <highchart id="chart1" config="vm.chartConfig" ng-init="vm.destroyResetZoom()"></highchart>
+                            <highchart class="highchart" id="chart1" config="vm.chartConfig" ng-init="vm.destroyResetZoom()"></highchart>
                             <div class="plot-filters">
                                 <label for="dischargeStart"> Start Date:</label>
                                 <input type="date" style="width:12%;" id="dischargeStart" ng-value="vm.extremes.min">&nbsp;
@@ -262,6 +263,7 @@
                                 </div>
                         </div>
                     </center>
+                    <div style="break-after:page"></div>
                     <center>
                         <div ng-if="!vm.heatChartConfig" class="panel panel-default reportSpinner">
                             &nbsp;<i class="fa fa-spinner fa-3x fa-spin loadingSpinner"></i>
@@ -275,6 +277,7 @@
                             </div>
                         </div>
                     </center> 
+                    <div style="break-after:page"></div>
                     <center>
                         <div ng-if="!vm.dischargeChartConfig" class="panel panel-default reportSpinner">
                             &nbsp;<i class="fa fa-spinner fa-3x fa-spin loadingSpinner"></i>
@@ -317,25 +320,25 @@
                                     </div>
                                 <div ng-show="vm.USGSMeasuredAgeQualityData === 'age'"  style="clear:left; width: 230px;" ng-style="{'left': vm.logScaleDischarge ? '222px' : '680px', 'bottom': vm.logScaleDischarge ? '200px' : '220px'}">
                                     <div class="ageQualityLegend-item">
-                                        <span style="color: red;">Most Recent Measurement</span>
+                                        <span style="color: red !important;">Most Recent Measurement</span>
                                 </div>
                                 <div class="ageQualityLegend-item">
-                                    <span style="color: orange;">Measurements in the Last Year</span>
+                                    <span style="color: orange !important;">Measurements in the Last Year</span>
                                 </div>
                                 <div class="ageQualityLegend-item">
-                                    <span style="color: #0000cdcc;">Newer -&nbsp</span><span style="color: #0000cd4d;">Older Measurements</span>
+                                    <span style="color: #0000cdcc !important;">Newer -&nbsp</span><span style="color: #0000cd4d !important;">Older Measurements</span>
                                     </div>
                                 </div>
                                 
                                 <div ng-show="vm.USGSMeasuredAgeQualityData === 'quality'"  style="clear:left; width: 130px;" ng-style="{'left': vm.logScaleDischarge ? '222px' : '680px', 'bottom': vm.logScaleDischarge ? '200px' : '220px'}">
                                     <div class="ageQualityLegend-item">
-                                        <span style="color:#2ED017;">Excellent - Good</span>
+                                        <span style="color:#2ED017 !important;">Excellent - Good</span>
                                 </div>
                                 <div class="ageQualityLegend-item">
-                                    <span style="color:#E7F317;">Fair</span>
+                                    <span style="color:#E7F317 !important;">Fair</span>
                                 </div>
                                 <div class="ageQualityLegend-item">
-                                    <span style="color: #FFA200;">Poor</span>
+                                    <span style="color: #FFA200 !important;">Poor</span>
                                 </div>
                                 </div>
                                 </div>

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -15,17 +15,17 @@ if (window.location.host === 'test.streamstats.usgs.gov') {
 configuration.baseurls =
     {
         'NWISurl': 'https://waterservices.usgs.gov/nwis',
-        'StreamStatsServices': 'https://streamstats.usgs.gov',
+        'StreamStatsServices': 'https://test.streamstats.usgs.gov',
         'StreamStatsMapServices': 'https://gis.streamstats.usgs.gov',
         'NSS': 'https://test.streamstats.usgs.gov/nssservices',
-        'WaterUseServices': 'https://streamstats.usgs.gov/wateruseservices',
-        'StormRunoffServices': 'https://streamstats.usgs.gov/runoffmodelingservices',
+        'WaterUseServices': 'https://test.streamstats.usgs.gov/wateruseservices',
+        'StormRunoffServices': 'https://test.streamstats.usgs.gov/runoffmodelingservices',
         'ScienceBase': 'https://gis.usgs.gov/sciencebase2',
-        'GageStatsServices': 'https://streamstats.usgs.gov/gagestatsservices',
-        'WeightingServices': 'https://ss-weightingservices.streamstats.usgs.gov',
-        'SCStormRunoffServices': 'https://streamstats.usgs.gov/local/scrunoffservices',
-        'NationalMapServices': 'https://hydro.nationalmap.gov/arcgis/rest/services',
-        'FlowAnywhereRegressionServices': 'https://streamstats.usgs.gov/regressionservices'
+        'GageStatsServices': 'https://test.streamstats.usgs.gov/gagestatsservices',
+        'WeightingServices': 'https://streamstats.usgs.gov/channelweightingservices',
+        'FlowAnywhereRegressionServices': 'https://streamstats.usgs.gov/regressionservices',
+        'BatchProcessorServices': 'https://dev.streamstats.usgs.gov/batchprocessor', // Will need to change this if running locally and want to use production data
+        'PourPointServices': 'https://test.streamstats.usgs.gov/pourpoint'
     };
 
 //override streamstats arguments if on production, these get overriden again in MapController after load balancer assigns a server

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -15,17 +15,17 @@ if (window.location.host === 'test.streamstats.usgs.gov') {
 configuration.baseurls =
     {
         'NWISurl': 'https://waterservices.usgs.gov/nwis',
-        'StreamStatsServices': 'https://test.streamstats.usgs.gov',
+        'StreamStatsServices': 'https://streamstats.usgs.gov',
         'StreamStatsMapServices': 'https://gis.streamstats.usgs.gov',
         'NSS': 'https://test.streamstats.usgs.gov/nssservices',
-        'WaterUseServices': 'https://test.streamstats.usgs.gov/wateruseservices',
-        'StormRunoffServices': 'https://test.streamstats.usgs.gov/runoffmodelingservices',
+        'WaterUseServices': 'https://streamstats.usgs.gov/wateruseservices',
+        'StormRunoffServices': 'https://streamstats.usgs.gov/runoffmodelingservices',
         'ScienceBase': 'https://gis.usgs.gov/sciencebase2',
-        'GageStatsServices': 'https://test.streamstats.usgs.gov/gagestatsservices',
-        'WeightingServices': 'https://streamstats.usgs.gov/channelweightingservices',
-        'FlowAnywhereRegressionServices': 'https://streamstats.usgs.gov/regressionservices',
-        'BatchProcessorServices': 'https://dev.streamstats.usgs.gov/batchprocessor', // Will need to change this if running locally and want to use production data
-        'PourPointServices': 'https://test.streamstats.usgs.gov/pourpoint'
+        'GageStatsServices': 'https://streamstats.usgs.gov/gagestatsservices',
+        'WeightingServices': 'https://ss-weightingservices.streamstats.usgs.gov',
+        'SCStormRunoffServices': 'https://streamstats.usgs.gov/local/scrunoffservices',
+        'NationalMapServices': 'https://hydro.nationalmap.gov/arcgis/rest/services',
+        'FlowAnywhereRegressionServices': 'https://streamstats.usgs.gov/regressionservices'
     };
 
 //override streamstats arguments if on production, these get overriden again in MapController after load balancer assigns a server

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -800,6 +800,15 @@ div.leaflet-top > .elevation {
             background-color: #0db9f0 !important;
         } 
 
+        .highcharts-no-tooltip.highcharts-button.highcharts-reset-zoom.highcharts-button-normal {
+            color: transparent;
+            display: none !important;
+            height: 0px;
+            width: 0px
+        }
+        .highcharts-tooltip { 
+            display: none; 
+        }
         /* gageplots formatting end */
 
         .hidden-print {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -777,12 +777,31 @@ div.leaflet-top > .elevation {
             visibility: hidden;
             -webkit-print-color-adjust: exact !important;
         }
+        
         .wim-alert-warning {
             background-color: #fdb81e !important;
         }
         table .wim-warning {
             background-color: #fdb81e !important;
         }
+
+        /* gageplots formatting start*/
+        .well {
+            justify-content:center;
+            align-items:center;
+            width:1100px;
+            height:1000px;
+        }
+        .stagedischarge-inputs-container {
+            display: inline;
+        }
+
+        .gageplot-slider .rz-bar{
+            background-color: #0db9f0 !important;
+        } 
+
+        /* gageplots formatting end */
+
         .hidden-print {
             display: none !important;
         }
@@ -812,6 +831,7 @@ div.leaflet-top > .elevation {
         .modal-footer {
             border-top:0;
         }
+
         .leaflet-control-container{
             display: none!important;
         }
@@ -1605,14 +1625,14 @@ Batch processor modal
     width: 20px;
     height: 20px;
     cursor: pointer;
-    background-color: #0db9f0;
+    background-color: #0db9f0 !important;
     -webkit-border-radius: 16px;
     -moz-border-radius: 16px;
     border-radius: 5;
 }
 
 .gageplot-slider .rz-pointer.rz-active:after {
-    background-color: #0db9f0;
+    background-color: #0db9f0 !important;
 }
 
 .gageplot-slider .rz-bubble {
@@ -1628,7 +1648,7 @@ Batch processor modal
     left: 5px;
     width: 8px;
     height: 8px;
-    background: #0db9f0;
+    background: #0db9f0 !important;
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;
@@ -1636,7 +1656,7 @@ Batch processor modal
 }
 
 .gageplot-slider .rz-pointer:hover:after {
-    background-color: #0db9f0;
+    background-color: #0db9f0 !important;
 }
 
 .slider-text {


### PR DESCRIPTION
Closes #1971
- Adjusts printer CSS
- Adds forced page breaks between plots in the HTML
- Fixes issue of ALL flood stats showing up when page printed, now it should just be the selected ones

 Closes #1976 
- Adds note about toggling data series to each plot

