### PR TITLE
Fixes #1978

### DIFF
--- a/src/Controllers/SCStormRunoffController.js
+++ b/src/Controllers/SCStormRunoffController.js
@@ -626,10 +626,7 @@ var StreamStats;
                             response.data[0].regressionRegions.forEach(function (regressionregion) {
                                 if (regressionregion.code == 'GC1583' || regressionregion.code == 'GC1584' || regressionregion.code == 'GC1585' || regressionregion.code == 'GC1586') {
                                     regressionregion.results.forEach(function (result) {
-                                        console.log(_this.SelectedAEP.value);
-                                        console.log(result);
                                         if (result.code == 'U' + _this.SelectedAEP.code) {
-                                            console.log('inside');
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     });
@@ -652,10 +649,7 @@ var StreamStats;
                             response.data[0].regressionRegions.forEach(function (regressionregion) {
                                 if (regressionregion.citationID == 191) {
                                     regressionregion.results.forEach(function (result) {
-                                        console.log(_this.SelectedAEP.value);
-                                        console.log(result);
                                         if (result.code == _this.SelectedAEP.code) {
-                                            console.log('inside');
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     });

--- a/src/Controllers/SCStormRunoffController.js
+++ b/src/Controllers/SCStormRunoffController.js
@@ -47,27 +47,35 @@ var StreamStats;
                 _this.isSyntheticUHOpen = false;
                 _this.AEPOptions = [{
                         "name": "50%",
+                        "code": "PK50AEP",
                         "value": 50
                     }, {
                         "name": "20%",
+                        "code": "PK20AEP",
                         "value": 20
                     }, {
                         "name": "10%",
+                        "code": "PK10AEP",
                         "value": 10
                     }, {
                         "name": "4%",
+                        "code": "PK4AEP",
                         "value": 4
                     }, {
                         "name": "2%",
+                        "code": "PK2AEP",
                         "value": 2
                     }, {
                         "name": "1%",
+                        "code": "PK1AEP",
                         "value": 1
                     }, {
                         "name": ".5%",
+                        "code": "PK0_5AEP",
                         "value": 0.5
                     }, {
                         "name": ".2%",
+                        "code": "PK0_2AEP",
                         "value": 0.2
                     }];
                 _this.prfForm = {
@@ -618,7 +626,10 @@ var StreamStats;
                             response.data[0].regressionRegions.forEach(function (regressionregion) {
                                 if (regressionregion.code == 'GC1583' || regressionregion.code == 'GC1584' || regressionregion.code == 'GC1585' || regressionregion.code == 'GC1586') {
                                     regressionregion.results.forEach(function (result) {
-                                        if (result.name.indexOf(_this.SelectedAEP.value) !== -1) {
+                                        console.log(_this.SelectedAEP.value);
+                                        console.log(result);
+                                        if (result.code == 'U' + _this.SelectedAEP.code) {
+                                            console.log('inside');
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     });
@@ -641,7 +652,10 @@ var StreamStats;
                             response.data[0].regressionRegions.forEach(function (regressionregion) {
                                 if (regressionregion.citationID == 191) {
                                     regressionregion.results.forEach(function (result) {
-                                        if (result.name.indexOf(_this.SelectedAEP.value) !== -1) {
+                                        console.log(_this.SelectedAEP.value);
+                                        console.log(result);
+                                        if (result.code == _this.SelectedAEP.code) {
+                                            console.log('inside');
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     });

--- a/src/Controllers/SCStormRunoffController.ts
+++ b/src/Controllers/SCStormRunoffController.ts
@@ -112,27 +112,35 @@ module StreamStats.Controllers {
 
         public AEPOptions = [{
             "name": "50%",
+            "code": "PK50AEP",
             "value": 50
           }, {
             "name": "20%",
+            "code": "PK20AEP",
             "value": 20
           }, {
             "name": "10%",
+            "code": "PK10AEP",
             "value": 10
         }, {
             "name": "4%",
+            "code": "PK4AEP",
             "value": 4
         }, {
             "name": "2%",
+            "code": "PK2AEP",
             "value": 2
         }, {
             "name": "1%",
+            "code": "PK1AEP",
             "value": 1
         }, {
             "name": ".5%",
+            "code": "PK0_5AEP",
             "value": 0.5
         }, {
             "name": ".2%",
+            "code": "PK0_2AEP",
             "value": 0.2
         }];
         private _selectedAEP;
@@ -819,7 +827,10 @@ module StreamStats.Controllers {
                             response.data[0].regressionRegions.forEach(regressionregion => {
                                 if (regressionregion.code == 'GC1583' || regressionregion.code == 'GC1584' || regressionregion.code == 'GC1585' || regressionregion.code == 'GC1586') {
                                     regressionregion.results.forEach(result => {
-                                        if (result.name.indexOf(this.SelectedAEP.value) !== -1){
+                                        console.log(this.SelectedAEP.value)
+                                        console.log(result)
+                                        if (result.code == 'U' + this.SelectedAEP.code){ // Need to add a U to code for Urban
+                                            console.log('inside')
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     })
@@ -842,7 +853,10 @@ module StreamStats.Controllers {
                             response.data[0].regressionRegions.forEach(regressionregion => {
                                 if (regressionregion.citationID == 191) { //2022, Magnitude and Frequency of Floods for Rural Streams in Georgia, South Carolina, and North Carolina, 2017--Results
                                     regressionregion.results.forEach(result => {
-                                        if (result.name.indexOf(this.SelectedAEP.value) !== -1){
+                                        console.log(this.SelectedAEP.value)
+                                        console.log(result)
+                                        if (result.code == this.SelectedAEP.code){
+                                            console.log('inside')
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     })

--- a/src/Controllers/SCStormRunoffController.ts
+++ b/src/Controllers/SCStormRunoffController.ts
@@ -827,10 +827,7 @@ module StreamStats.Controllers {
                             response.data[0].regressionRegions.forEach(regressionregion => {
                                 if (regressionregion.code == 'GC1583' || regressionregion.code == 'GC1584' || regressionregion.code == 'GC1585' || regressionregion.code == 'GC1586') {
                                     regressionregion.results.forEach(result => {
-                                        console.log(this.SelectedAEP.value)
-                                        console.log(result)
                                         if (result.code == 'U' + this.SelectedAEP.code){ // Need to add a U to code for Urban
-                                            console.log('inside')
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     })
@@ -853,10 +850,7 @@ module StreamStats.Controllers {
                             response.data[0].regressionRegions.forEach(regressionregion => {
                                 if (regressionregion.citationID == 191) { //2022, Magnitude and Frequency of Floods for Rural Streams in Georgia, South Carolina, and North Carolina, 2017--Results
                                     regressionregion.results.forEach(result => {
-                                        console.log(this.SelectedAEP.value)
-                                        console.log(result)
                                         if (result.code == this.SelectedAEP.code){
-                                            console.log('inside')
                                             weightedAEP += (result.value * (regressionregion.percentWeight / 100.0));
                                         }
                                     })


### PR DESCRIPTION
- Changed to use code to grab the correct results
- Was happening with Urban results so made the change there as well

To test I used the points in the Word document Kitty sent, 34.44148, -81.03518 and 33.96926, -79.18598 then compared the results to the chart that was provided in the document. 

We only want to include PKXXAEP correct? 